### PR TITLE
Set content type on upload

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -44,6 +44,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -115,6 +116,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
             throws IOException, InterruptedException {
         LOGGER.log(Level.FINE, "Archiving from {0}: {1}", new Object[] { workspace, artifacts });
         Map<String, URL> artifactUrls = new HashMap<>();
+        Map<String, String> contentTypes = new HashMap<>();
         BlobStore blobStore = getContext().getBlobStore();
 
         // Map artifacts to urls for upload
@@ -123,23 +125,54 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
             String blobPath = getBlobPath(path);
             Blob blob = blobStore.blobBuilder(blobPath).build();
             blob.getMetadata().setContainer(provider.getContainer());
+            String contentType = workspace.act(new ContentTypeGuesser(entry.getKey()));
+            if (contentType != null) {
+                contentTypes.put(entry.getValue(), contentType);
+            }
+            blob.getMetadata().getContentMetadata().setContentType(contentType);
             artifactUrls.put(entry.getValue(), provider.toExternalURL(blob, HttpMethod.PUT));
         }
 
-        workspace.act(new UploadToBlobStorage(artifactUrls, listener));
+        workspace.act(new UploadToBlobStorage(artifactUrls, contentTypes, listener));
         listener.getLogger().printf("Uploaded %s artifact(s) to %s%n", artifactUrls.size(), provider.toURI(provider.getContainer(), getBlobPath("artifacts/")));
+    }
+
+    private static class ContentTypeGuesser extends MasterToSlaveFileCallable<String> {
+        private static final long serialVersionUID = 5743824603401251506L;
+
+        private final String relPath;
+
+        ContentTypeGuesser(String relPath) {
+            this.relPath = relPath;
+        }
+
+        @Override
+        public String invoke(File f, VirtualChannel channel) {
+            try {
+                File theFile = new File(f, relPath);
+                String contentType = Files.probeContentType(theFile.toPath());
+                if (null == contentType) {
+                    contentType = URLConnection.guessContentTypeFromName(theFile.getName());
+                }
+                return contentType;
+            } catch (IOException e) {
+                return null;
+            }
+        }
     }
 
     private static class UploadToBlobStorage extends MasterToSlaveFileCallable<Void> {
         private static final long serialVersionUID = 1L;
 
         private final Map<String, URL> artifactUrls; // e.g. "target/x.war", "http://..."
+        private final Map<String, String> contentTypes;
         private final TaskListener listener;
         // Bind when constructed on the master side; on the agent side, deserialize the same configuration.
         private final RobustHTTPClientEx client = JCloudsArtifactManager.client;
 
-        UploadToBlobStorage(Map<String, URL> artifactUrls, TaskListener listener) {
+        UploadToBlobStorage(Map<String, URL> artifactUrls, Map<String, String> contentTypes, TaskListener listener) {
             this.artifactUrls = artifactUrls;
+            this.contentTypes = contentTypes;
             this.listener = listener;
         }
 
@@ -147,7 +180,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
         public Void invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
             try {
                 for (Map.Entry<String, URL> entry : artifactUrls.entrySet()) {
-                    client.uploadFile(new File(f, entry.getKey()), entry.getValue(), listener);
+                    client.uploadFile(new File(f, entry.getKey()), contentTypes.get(entry.getKey()), entry.getValue(), listener);
                 }
             } finally {
                 listener.getLogger().flush();

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -166,7 +166,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
         private static final long serialVersionUID = 1L;
 
         private final Map<String, URL> artifactUrls; // e.g. "target/x.war", "http://..."
-        private final Map<String, String> contentTypes;
+        private final Map<String, String> contentTypes; // e.g. "target/x.zip, "application/zip"
         private final TaskListener listener;
         // Bind when constructed on the master side; on the agent side, deserialize the same configuration.
         private final RobustHTTPClientEx client = JCloudsArtifactManager.client;

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -148,14 +148,15 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
 
         @Override
         public String invoke(File f, VirtualChannel channel) {
+            File theFile = new File(f, relPath);
             try {
-                File theFile = new File(f, relPath);
                 String contentType = Files.probeContentType(theFile.toPath());
                 if (null == contentType) {
                     contentType = URLConnection.guessContentTypeFromName(theFile.getName());
                 }
                 return contentType;
             } catch (IOException e) {
+                LOGGER.log(Level.FINE, "Unable to determine content type for file: " + theFile, e);
                 return null;
             }
         }

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/RobustHTTPClientEx.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/RobustHTTPClientEx.java
@@ -208,9 +208,16 @@ public class RobustHTTPClientEx implements Serializable {// extends RobustHTTPCl
      * Upload a file to a URL.
      */
     public void uploadFile(File f, URL url, TaskListener listener) throws IOException, InterruptedException {
+        uploadFile(f, null, url, listener);
+    }
+
+    public void uploadFile(File f, String contentType, URL url, TaskListener listener) throws IOException, InterruptedException {
         connect("upload", "upload " + f + " to " + sanitize(url), client -> {
             HttpPut put = new HttpPut(url.toString());
             put.setEntity(new FileEntity(f));
+            if (contentType != null) {
+                put.setHeader("Content-Type", contentType);
+            }
             return client.execute(put);
         }, response -> {}, listener);
     }

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -203,11 +203,8 @@ public class S3BlobStore extends BlobStoreProvider {
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(container, name)
             .withExpiration(expiration)
-            .withMethod(awsMethod);
-
-        if (contentType != null) {
-            generatePresignedUrlRequest.setContentType(contentType);
-        }
+            .withMethod(awsMethod)
+            .withContentType(contentType);
 
         return builder.build().generatePresignedUrl(generatePresignedUrlRequest);
     }

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -55,6 +55,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.google.common.base.Supplier;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -185,10 +186,13 @@ public class S3BlobStore extends BlobStoreProvider {
         String name = blob.getMetadata().getName();
         LOGGER.log(Level.FINE, "Generating presigned URL for {0} / {1} for method {2}",
                 new Object[] { container, name, httpMethod });
+        String contentType = null;
         com.amazonaws.HttpMethod awsMethod;
         switch (httpMethod) {
         case PUT:
             awsMethod = com.amazonaws.HttpMethod.PUT;
+            // Only set content type for upload URLs, so that the right S3 metadata gets set
+            contentType = blob.getMetadata().getContentMetadata().getContentType();
             break;
         case GET:
             awsMethod = com.amazonaws.HttpMethod.GET;
@@ -196,7 +200,16 @@ public class S3BlobStore extends BlobStoreProvider {
         default:
             throw new IOException("HTTP Method " + httpMethod + " not supported for S3");
         }
-        return builder.build().generatePresignedUrl(container, name, expiration, awsMethod);
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(container, name)
+            .withExpiration(expiration)
+            .withMethod(awsMethod);
+
+        if (contentType != null) {
+            generatePresignedUrlRequest.setContentType(contentType);
+        }
+
+        return builder.build().generatePresignedUrl(generatePresignedUrlRequest);
     }
 
     @Symbol("s3")

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
@@ -54,6 +54,7 @@ import org.jvnet.hudson.test.TestBuilder;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.cloudbees.hudson.plugins.folder.Folder;
+import com.gargoylesoftware.htmlunit.WebResponse;
 
 import hudson.FilePath;
 import hudson.Launcher;
@@ -304,6 +305,63 @@ public class JCloudsArtifactManagerTest extends S3AbstractTest {
         assertThat(j.createWebClient().withBasicCredentials("admin").goTo(url, jsonType).getWebResponse().getContentAsString(), containsString(snippet));
         j.createWebClient().withBasicCredentials("dev1").assertFails(url, 404);
         assertThat(j.createWebClient().withBasicCredentials("dev2").goTo(url, jsonType).getWebResponse().getContentAsString(), containsString(snippet));
+    }
+
+    @Issue("JENKINS-50772")
+    @Test
+    public void contentTypeText() throws Exception {
+        final String expectedContents = "some regular text";
+        final String expectedContentType = "text/plain";
+
+        CredentialsAwsGlobalConfiguration.get().setCredentialsId("bogus"); // force sessionCredentials to call getCredentials
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(getArtifactManagerFactory(null, null));
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {writeFile file: 'f.txt', text: '" + expectedContents + "'; archiveArtifacts 'f.txt'}", true));
+        j.buildAndAssertSuccess(p);
+
+        String url = "job/p/1/artifact/f.txt";
+        WebResponse response = j.createWebClient().goTo(url, null).getWebResponse();
+        assertThat(response.getContentAsString(), equalTo(expectedContents));
+        assertThat(response.getContentType(), equalTo(expectedContentType));
+    }
+
+    @Issue("JENKINS-50772")
+    @Test
+    public void contentTypeHtml() throws Exception {
+        final String expectedContents = "<html><header></header><body>Test file contents</body></html>";
+        final String expectedContentType = "text/html";
+
+        CredentialsAwsGlobalConfiguration.get().setCredentialsId("bogus"); // force sessionCredentials to call getCredentials
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(getArtifactManagerFactory(null, null));
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {writeFile file: 'f.html', text: '" + expectedContents + "'; archiveArtifacts 'f.html'}", true));
+        j.buildAndAssertSuccess(p);
+
+        String url = "job/p/1/artifact/f.html";
+        WebResponse response = j.createWebClient().goTo(url, null).getWebResponse();
+        assertThat(response.getContentAsString(), equalTo(expectedContents));
+        assertThat(response.getContentType(), equalTo(expectedContentType));
+    }
+
+    @Issue("JENKINS-50772")
+    @Test
+    public void contentTypeUnknown() throws Exception {
+        final String expectedContents = "";
+        final String expectedContentType = "binary/octet-stream";
+
+        CredentialsAwsGlobalConfiguration.get().setCredentialsId("bogus"); // force sessionCredentials to call getCredentials
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(getArtifactManagerFactory(null, null));
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {writeFile file: 'f', text: '" + expectedContents + "'; archiveArtifacts 'f'}", true));
+        j.buildAndAssertSuccess(p);
+
+        String url = "job/p/1/artifact/f";
+        WebResponse response = j.createWebClient().goTo(url, null).getWebResponse();
+        assertThat(response.getContentAsString(), equalTo(expectedContents));
+        assertThat(response.getContentType(), equalTo(expectedContentType));
     }
 
     //@Test


### PR DESCRIPTION
Specify content type for uploaded files in S3, where one could be determined.

This requires a change to RobustHTTPClient to accept a content type parameter for an uploaded file, and for simplicity's sake I've opted to include a copy of that class in this repo. For a proper upstream PR, the changes to RobustHTTPClientEx in this commit would need to be made in the `org.jenkins-ci.plugins.apache-httpcomponents-client-4-api` project instead.

As far as determining the appropriate content for a given file, at first `java.nio.Files#probeContentType()` is called to see if that returns a non-null content type. If unsuccessful, `java.net.URLConnection#guessContentTypeFromName()` is used to pick a content type based on the file extension. For each file in the list of artifacts to be uploaded, the content type (if any) is recorded in a separate map. Additionally, the content type is passed in to the S3BlobStore method which calculates the presigned URL since the content-type header is part of the signed URL and needs to be known before generating the URL. Next, during the loop which uploads the artifacts to S3, the recorded content types for each file (again, if any was able to be determined for a given file) are retrieved and passed in to the RobustHTTPClient's `uploadFile` call.

In S3BlobStore, we need to use `GeneratePresignedUrlRequest` to generate the presigned URL as it allows us to specify the "Content-Type" header in the generated URL. The existing `AmazonS3ClientBuilder` does not provide this option.

The existing RobustHTTPClient `uploadFile(File, URL, TaskListener)` method signature is preserved, and changed to call the new `uploadFile(File, String, URL, TaskListener)` which includes an additional parameter for specifying the content type. If this is non-null, the "Content-Type" HTTP header will be set accordingly. This is necessary, or the presigned URL which included the "Content-Type" header, and the `GET` request used to perform the upload do not match and will throw an AWS exception complaining that "The request signature we calculated does not match the signature you provided."